### PR TITLE
fix: Change `blocks.chunk` field type from `set` to `list`

### DIFF
--- a/src/configs.rs
+++ b/src/configs.rs
@@ -244,7 +244,7 @@ pub(crate) async fn migrate(
             CREATE TABLE IF NOT EXISTS blocks (
                 block_height varint,
                 block_hash varchar,
-                chunks set<varchar>,
+                chunks list<varchar>,
                 PRIMARY KEY (block_hash)
             )
         ",


### PR DESCRIPTION
`set` is a sorted collection in ScyllaDB and this ruins the order of stored chunk hashes in the `blocks` table.

I've updated the `configs::migrate` function which provisions the tables.

This change is important and leads us to the necessity to reindex the data we already indexed.

I am going to alter the table manually (if it is possible) and rerun both indexer instances:

- the one following the tip of the network
- the one that indexes the history